### PR TITLE
Cayden simple edits

### DIFF
--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -51,4 +51,4 @@ theorem ConvexEmptyIn.iff_triangles {s : Finset Point} {S : Set Point}
 \end{proof}
 
 In the next section,
-we show how to encode which triangles (and, by the above theorem, which $k$-holes) are empty in a pointset with boolean variables.
+we show how to use boolean variables to encode which triangles (and, by the above theorem, which $k$-holes) are empty in a pointset.

--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -49,5 +49,6 @@ theorem ConvexEmptyIn.iff_triangles {s : Finset Point} {S : Set Point}
     %  Indeed, assume $s$ is not empty w.r.t. $S$, there is a point $p \in S \setminus s$ that lies inside the convex hull of $s$. Because $P$ is a partition of the convex hull of $s$, point $p$ must be inside some $t \in P \subseteq T$.
     %  To see convexity, we can reason contrapositively again. If $s$ is not convex, then there is a point $p \in s$ that lies inside the convex hull of $s$, and thus lies inside a triangle $t \in P$.
 \end{proof}
-    
-The next section shows how boolean variables can be used to encode which triangles are empty w.r.t.~a pointset, which as the previous theorem shows, can be used to encode the presence or absence of $k$-holes.
+
+In the next section,
+we show how to encode which triangles (and, by the above theorem, which $k$-holes) are empty in a pointset with boolean variables.

--- a/ITP/intro.tex
+++ b/ITP/intro.tex
@@ -45,16 +45,6 @@ Our formalization is publicly available at \url{https://github.com/bsubercaseaux
 Formal verification makes the SAT \emph{solving} step trustworthy.
 For example, theorem provers and formal methods tools have been used to verify solvers~\cite{10maric_formal_verification_modern_sat_solver_shallow_embedding_isabelle_hol,oeVersatVerifiedModern2012,skotam_creusat_2022}
 and proof checkers~\cite{lammichEfficientVerifiedSAT2020,tanVerifiedPropagationRedundancy2023}.
-
-
-The \emph{reduction} step has also received scrutiny,
-but seemingly not as much.
-
-Giljeg\r{a}rd and Wennerbreck~\cite{GilAndWennerbeck} provide a general \textsf{CakeML} library
-of verified SAT encodings
-which they use to write verified reductions of different puzzles
-
-
 However, the \emph{reduction} step has not received similar scrutiny,
 with only a few reductions having been verified.
 For instance,
@@ -69,8 +59,8 @@ were too large to extract human-readable proofs.
 More generally,
 Giljeg\r{a}rd and Wennerbreck~\cite{GilAndWennerbeck} built a \textsf{CakeML} library
 of verified SAT encodings,
-which they used to write verified SAT reductions for different problems
-(e.g., Sudoku, Kakuro, the \emph{N-queens} problem).
+which they used to write verified SAT reductions for different puzzles,
+such as the \emph{N-queens} problem. 
 In this paper,
 we use reduction verification techniques based on those of Codel, Avigad, and Heule~\cite{Cayden},
 which they developed in Lean.

--- a/ITP/intro.tex
+++ b/ITP/intro.tex
@@ -1,12 +1,12 @@
 Mathematicians are often rightfully skeptical of proofs that rely on extensive computation (e.g., the controversy around the four color theorem~\cite{Walters2004ItAT}).
-Nonetheless, many mathematically-interesting theorems have been resolved that way.
+Nonetheless, many mathematically-interesting theorems have been resolved with the help of computers.
 SAT solving in particular has been a powerful tool for mathematics, successfully resolving
 Keller's conjecture~\cite{brakensiek2023resolution},
 the packing chromatic number of the infinite grid~\cite{Subercaseaux_Heule_2023},
 the Pythagorean triples problem~\cite{Heule_2016},
 Lam's problem~\cite{21bright_sat_based_resolution_lams_problem},
 and one case of the Erd\H{o}s discrepancy conjecture~\cite{konev2014sat}.
-All of these proofs rely on the same two-step structure:
+Notably, all of these proofs follow the same two-step structure:
 \begin{itemize}
 \item \textbf{(Reduction)} Show that the mathematical theorem of interest is true if a concrete propositional formula~$\phi$ is unsatisfiable.
 \item \textbf{(Solving)} Show that $\phi$ is indeed unsatisfiable.
@@ -15,19 +15,19 @@ All of these proofs rely on the same two-step structure:
 % \footnote{A variant of this procedure uses \emph{satisfying assignments} for $P$ to construct explicit witnesses for the original theorem, but we focus on the unsatisfiable case.}
 % \end{itemize}
 
-Formal methods researchers have devoted significant attention to making the \emph{solving} step reliable, reproducible and trustworthy.
-Modern SAT solvers produce proofs of unsatisfiability in formal systems
+Formal methods researchers have developed techniques that make the \emph{solving} step reliable, reproducible, and trustworthy.
+For example,
+modern SAT solvers produce proofs of unsatisfiability in formal proof systems
 such as DRAT~\cite{drat-trim14}
 that can in turn be checked with verified proof checkers
 such as \texttt{cake\_lpr}~\cite{tanVerifiedPropagationRedundancy2023}.
 These tools ensure that when a SAT solver declares a formula~$\phi$ to be unsatisfiable, the formula is indeed unsatisfiable.
-In contrast, the \emph{reduction} step can use problem-specific mathematical insights that, when left unverified, threaten the trustworthiness of SAT-based proofs in mathematics.
-% The correctness of the \emph{reduction} step, however, has received
-% leaving room for doubt that any results relying on such reduction arguments are correct.
-A perfect example of the complexity of this reduction step can be found in a recent breakthrough of Heule and Scheucher~\cite{emptyHexagonNumber} in discrete computational geometry.
+In contrast, the \emph{reduction} step is not as trustworthy,
+as it can use problem-specific mathematical insights that, when left unverified, threaten the correctness of the proof.
+A perfect example of a complex reduction can be found in a recent breakthrough in discrete computational geometry due to Heule and Scheucher~\cite{emptyHexagonNumber}.
 They constructed (and solved) a formula $\phi$ whose unsatisfiability implies that every set of 30 points in the plane, without three in a common line, must contain an empty convex hexagon.
 However, as is common with such results, their reduction argument was only sketched, relied heavily on intuition,
-and left several gaps to be filled in.
+and had several gaps.
 
 % result from Heule and Scheucher~\cite{emptyHexagonNumber} falls into this category.
 % They resolve a variant of the Happy Ending Problem,
@@ -35,40 +35,50 @@ and left several gaps to be filled in.
 % Their proof relies on a complicated reduction to SAT
 % involving numerous nontrivial geometric optimizations and symmetry-breaking arguments.
 
-In this paper we complete and formalize the reduction of Heule and Scheucher~\cite{emptyHexagonNumber}
-in the Lean theorem prover~\cite{demouraLeanTheoremProver2015}.
-We do so by connecting existing geometric definitions
+In this paper we complete and formalize their reduction in the Lean theorem prover~\cite{demouraLeanTheoremProver2015}. We do so by connecting existing geometric definitions
 in the mathematical proof library \textsf{mathlib}~\cite{The_mathlib_Community_2020}
 to the unsatisfiability of a particular SAT instance, thus setting a new standard for verifying results which rely on extensive computation.
 Our formalization is publicly available at \url{https://github.com/bsubercaseaux/EmptyHexagonLean/tree/itp2024}.
 
 
 \subparagraph*{Verification of SAT proofs.}
-Formal verification plays a crucial role in certifying the \emph{solving} step of SAT-based results.
+Formal verification makes the SAT \emph{solving} step trustworthy.
 For example, theorem provers and formal methods tools have been used to verify solvers~\cite{10maric_formal_verification_modern_sat_solver_shallow_embedding_isabelle_hol,oeVersatVerifiedModern2012,skotam_creusat_2022}
 and proof checkers~\cite{lammichEfficientVerifiedSAT2020,tanVerifiedPropagationRedundancy2023}.
+
+
 The \emph{reduction} step has also received scrutiny,
 but seemingly not as much.
-Cruz-Filipe and coauthors~\cite{formalPythagoreanTriples,LPAR-21:Formally_Proving_Boolean_Pythagorean}
-verified the reduction of the Pythagorean triples problem to SAT
-in the \textsf{Coq} proof assistant.
-Using \textsf{Isabelle/HOL},
-Delemazure and colleagues~\cite{23delemazure_strategyproofness_proportionality_party_approval_multiwinner_elections}
-verified SAT-based results in social choice theory
-for which minimal unsatisfiable sets of clauses
-were too large to extract human-readable proofs.
+
 Giljeg\r{a}rd and Wennerbreck~\cite{GilAndWennerbeck} provide a general \textsf{CakeML} library
 of verified SAT encodings
 which they use to write verified reductions of different puzzles
+
+
+However, the \emph{reduction} step has not received similar scrutiny,
+with only a few reductions having been verified.
+For instance,
+Cruz-Filipe and coauthors~\cite{formalPythagoreanTriples,LPAR-21:Formally_Proving_Boolean_Pythagorean}
+used the \textsf{Coq} proof assistant
+to verify the reduction of the Pythagorean triples problem~\cite{Heule_2016} to SAT,
+and Delemazure and colleagues~\cite{23delemazure_strategyproofness_proportionality_party_approval_multiwinner_elections}
+used \textsf{Isabelle/HOL} to
+verify SAT-based results in social choice theory
+for which minimal unsatisfiable sets of clauses
+were too large to extract human-readable proofs.
+More generally,
+Giljeg\r{a}rd and Wennerbreck~\cite{GilAndWennerbeck} built a \textsf{CakeML} library
+of verified SAT encodings,
+which they used to write verified SAT reductions for different problems
 (e.g., Sudoku, Kakuro, the \emph{N-queens} problem).
-The reduction verification techniques we use in this paper
-are based on that of Codel, Avigad, and Heule~\cite{Cayden} in the Lean theorem prover.
+In this paper,
+we use reduction verification techniques based on those of Codel, Avigad, and Heule~\cite{Cayden},
+which they developed in Lean.
 
 Formal verification for SAT-based combinatorial geometry
 was pioneered by Marić~\cite{19maric_fast_formal_proof_erdos_szekeres_conjecture_convex_polygons_most_six_points}.
-He developed a reduction of a case of the Happy Ending Problem to SAT
-and formally verified it in \textsf{Isabelle/HOL}.
-We give a detailed comparison between his work and ours in~\Cref{sec:related-work}.
+He formally verified a reduction of a case of the Happy Ending Problem (see below) to SAT in \textsf{Isabelle/HOL}.
+We compare our work to his in~\Cref{sec:related-work}.
 
 \subparagraph*{Lean.}
 Initially developed by Leonardo de Moura in 2013~\cite{demouraLeanTheoremProver2015},
@@ -80,7 +90,7 @@ A major selling point for Lean is the \textsf{mathlib} project~\cite{The_mathlib
 a monolithic formalization of foundational mathematics.
 By relying on \textsf{mathlib} for definitions, lemmas, and proof tactics,
 mathematicians can focus on the interesting components of a formalization
-while avoiding duplication of proof efforts across formalizations.
+while avoiding duplication of proof efforts.
 In turn, by making a formalization compatible with \textsf{mathlib},
 future proof efforts can rely on work done today.
 In this spirit, we connect our results to~\textsf{mathlib} as much as possible.
@@ -99,7 +109,7 @@ Indeed, it is known that $g(5) = 9$ and $g(6) = 17$,
 with the latter result obtained by Szekeres and Peters 71 years after the initial conjecture
 via exhaustive computer search~\cite{06szekeres_computer_solution_17_point_erdos_szekeres_problem}.
 Larger cases remain open,
-with $g(k) \leq 2^{k+o(k)}$ the best known upper bound~\cite{suk2017erdos,holmsen2017two}.
+with $g(k) \leq 2^{k+o(k)}$ being the best known upper bound~\cite{suk2017erdos,holmsen2017two}.
 This problem is now known as the \emph{Happy Ending Problem},
 as it led to the marriage of Klein and Szekeres.
 
@@ -116,7 +126,7 @@ avoid $k$-holes for $k \geq 7$~\cite{hortonSetsNoEmpty1983}.
 Only $h (6)$ remained.
 The \emph{Empty Hexagon Theorem},
 establishing $h(6)$ to be finite,
-was proven independently by Gerken and Nicolás in 2006~\cite{gerkenEmptyConvexHexagons2008,nicolasEmptyHexagonTheorem2007}.
+was proven independently by Gerken~\cite{gerkenEmptyConvexHexagons2008} and Nicolás~\cite{nicolasEmptyHexagonTheorem2007} in 2006.
 In 2008, Valtr narrowed the range of possible values down to $30 \leq h(6) \leq 1717$,
 where the problem remained until the breakthrough by Heule and Scheucher~\cite{emptyHexagonNumber},
 who used a SAT solver to prove that $h(6) \leq 30$,

--- a/ITP/main.tex
+++ b/ITP/main.tex
@@ -165,7 +165,7 @@ stringstyle=\color{stringcolor}
   %  that have been successfully applied to similar Erd\H{o}s-Szekeres-type problems.
   % In particular, our framework connects standard geometric objects to propositional assignments.
   We see this as a key step towards the formal verification of other SAT-based results in geometry, since the abstractions we use have been successfully applied to similar problems.
-  Overall, we hope that our work sets a new standard for the verification of geometry problems backed by extensive computation,
+  Overall, we hope that our work sets a new standard for the verification of geometry problems relying on extensive computation,
   and that it increases the trust the mathematical community places in computer-assisted proofs.
 \end{abstract}
 

--- a/ITP/main.tex
+++ b/ITP/main.tex
@@ -157,13 +157,16 @@ stringstyle=\color{stringcolor}
 
 \begin{abstract}
   A recent breakthrough in computer-assisted mathematics showed that every set of $30$ points in the plane in general position (i.e., no three points on a common line) contains an empty convex hexagon. %, closing a line of research dating back to the 1930s.
-  With a combination of geometric insights and automated reasoning techniques, Heule and Scheucher constructed CNF formulas $\phi_n$, with $O(n^4)$ clauses, such that if $\phi_n$ is unsatisfiable then every set of $n$ points in general position must contain an empty convex hexagon.
+  Heule and Scheucher solved this problem with a combination of geometric insights and automated reasoning techniques
+  by constructing CNF formulas $\phi_n$, with $O(n^4)$ clauses,
+  such that if $\phi_n$ is unsatisfiable then every set of $n$ points in general position must contain an empty convex hexagon.
   An unsatisfiability proof for $n = 30$ was then found with a SAT solver using 17\,300 CPU hours of parallel computation. %, thus implying that the empty hexagon number $h(6)$ is equal to 30.
   In this paper, we formalize and verify this result in the Lean theorem prover. Our formalization covers ideas in discrete computational geometry and SAT encoding techniques by introducing a framework that connects geometric objects to propositional assignments.
   %  that have been successfully applied to similar Erd\H{o}s-Szekeres-type problems.
   % In particular, our framework connects standard geometric objects to propositional assignments.
-  We see this as a key step towards the formal verification of other SAT-based results in geometry, since the abstractions we use have been successfully applied to similar Erd\H{o}s-Szekeres-type problems.
-  Overall, we hope that this work sets a new standard for verification when extensive computation is used for discrete geometry problems, and that it increases the trust the mathematical community has in computer-assisted proofs in this area.
+  We see this as a key step towards the formal verification of other SAT-based results in geometry, since the abstractions we use have been successfully applied to similar problems.
+  Overall, we hope that our work sets a new standard for the verification of geometry problems backed by extensive computation,
+  and that it increases the trust the mathematical community places in computer-assisted proofs.
 \end{abstract}
 
 

--- a/ITP/outline.tex
+++ b/ITP/outline.tex
@@ -1,4 +1,4 @@
-We will incrementally build sufficient machinery to prove:
+We will incrementally build sufficient machinery to prove the following theorem.
 
 \begin{theorem*}
 Any finite set of $30$ or more points in the plane in general position has a $6$-hole.

--- a/ITP/triple-orientations.tex
+++ b/ITP/triple-orientations.tex
@@ -1,3 +1,42 @@
+An essential step for obtaining computational proofs of geometric results is \emph{discretization}:
+problems concerning the existence of an object~$\mathcal{O}$ in a continuous search space like $\mathbb{R}^2$
+must be reformulated in terms of the existence of a discrete, finitely-representable object~$\mathcal{O}'$
+that a computer can search for.
+It is especially challenging to discretize problems in which the desired geometric object $\mathcal{O}$ is characterized by very specific coordinates of points,
+thus requiring the computer to use floating-point arithmetic,
+which suffers from numerical instability.
+Fortunately,
+this is not the case for Erd\H{o}s-Szekeres-type problems such as determining the value of $h(k)$,
+as their properties of interest (e.g., convexity and emptiness)
+can be described in terms of axiomatizable relationships between points and lines
+(e.g., point $p$ is above the line $\overrightarrow{qr}$, lines $\overrightarrow{qr}$ and $\overrightarrow{st}$ intersect, etc.)
+that are invariant under rotation, translation, and even small perturbations of the coordinates.
+%which makes them naturally well-suited for computation.
+We can discretize these relationships with boolean variables,
+thus making us agnostic to the specific coordinates of the points.
+The combinatorial abstraction that has been most widely used in Erd\H{o}s-Szekeres-type problems is that of \emph{triple orientations}~\cite{emptyHexagonNumber, scheucherTwoDisjoint5holes2020},
+also known as \emph{signotopes}~\cite{felsnerSweepsArrangementsSignotopes2001,subercaseaux2023minimizing}, 
+Knuth's \emph{counterclockwise relation}~\cite{knuthAxiomsHulls1992},
+or \emph{signatures}~\cite{szekeres_peters_2006}.
+Given points $p, q, r$, their \emph{triple-orientation} is defined as:
+\iffalse
+This poses a particular challenge for problems in which the desired geometric object $\mathcal{O}$ is characterized by very specific coordinates of points,
+requiring to deal with floating point arithmetic or numerical instability.
+Fortunately,
+this is not the case for Erd\H{o}s-Szekeres-type problems such as determining the value of $h(k)$, 
+which are naturally well-suited for computation.
+This is so because the properties of interest (e.g., convexity, emptiness) can be described in terms of axiomatizable relationships between points and lines
+(e.g., point $p$ is above the line $\overrightarrow{qr}$, lines $\overrightarrow{qr}$ and $\overrightarrow{st}$ intersect, etc.),
+which are invariant under rotations, translations, and even small perturbations of the coordinates. 
+This suggests the problems can be discretized in terms of boolean variables representing these relationships,
+forgetting the specific coordinates of the points.
+The combinatorial abstraction that has been most widely used in Erd\H{o}s-Szekeres-type problems is that of \emph{triple orientations}~\cite{emptyHexagonNumber, scheucherTwoDisjoint5holes2020},
+also known as \emph{signotopes}~\cite{felsnerSweepsArrangementsSignotopes2001,subercaseaux2023minimizing}, 
+Knuth's \emph{counterclockwise} relation~\cite{knuthAxiomsHulls1992},
+or \emph{signatures}~\cite{szekeres_peters_2006}.
+Given points $p, q, r$, their \emph{triple-orientation} is defined as:
+
+
 To use computers to solve geometry problems,
 we often need to \emph{discretize} the search space first.
 In many cases,
@@ -19,6 +58,7 @@ Knuth's \emph{counterclockwise} relation~\cite{knuthAxiomsHulls1992},
 or \emph{signatures}~\cite{szekeres_peters_2006}.
 An example is illustrated in~\Cref{fig:triple-orientation}.
 Given points $p, q, r$, their \emph{triple-orientation} is defined as:
+\fi
 \newcommand{\sign}{\operatorname{sign}}
 \[
   \sigma(p, q, r) = \sign \det \begin{pmatrix} p_x & q_x & r_x \\ p_y & q_y & r_y \\ 1 & 1 & 1 \end{pmatrix} = \begin{cases}
@@ -158,20 +198,23 @@ theorem OrientationProperty_HasEmptyKGon : OrientationProperty (HasEmptyKGon n)
 \end{lstlisting}
 
 The previous theorem is important for two reasons.
-First, if $\sigma$ is invariant under certain point transformations (e.g., rotations, translations, etc.), then any orientation property is invariant under the same transformations.
-Identifying these transformations allows us to perform symmetry breaking to simplify the search space while preserving the property of interest (see~\Cref{sec:symmetry-breaking}).
+First, if $\sigma$ is invariant under certain point transformations (e.g., rotations, translations, etc.),
+then any orientation property is invariant under the same transformations.
+This is a powerful tool for performing symmetry breaking (see~\Cref{sec:symmetry-breaking}).
 For a concrete example, consider a proof of an Erd\H{o}s-Szekeres-type result that starts by saying ``\emph{we assume without loss of generality that points $p_1, \ldots, p_n$ all have positive $y$-coordinates}.''
 Since $\sigma$ is invariant under translation, we can see that this assumption indeed does not impact the validity of the proof.
 
 Second,
 as introduced at the beginning of this section,
-SAT encodings for Erd\H{o}s-Szekeres-type problems use triple orientations to capture properties like convexity or emptiness,
+SAT encodings for Erd\H{o}s-Szekeres-type problems use triple orientations to capture properties like convexity and emptiness,
 thus discretizing the problem.
 Because we have proved that $\pi_k(S)$ is an orientation property,
-we find that the values of $\sigma$ for all triples of points in $S$ contain enough information to determine whether $\pi_k(S)$.
-Therefore,
-we may analyze the values of $\sigma$ for the point triples in $S$, a discrete space with at most $2^{n^3}$ possibilities,
-instead of grappling with a continuous search space on $n$ points, $\left(\mathbb{R}^2\right)^n$.
+the values of $\sigma$ on the points in $S$ contain enough information to determine whether $\pi_k(S)$.
+Therefore, we have proved that given $n$ points,
+it is enough to analyze the values of $\sigma$ over these points,
+a discrete space with at most $2^{n^3}$ possibilities,
+instead of grappling with a continuous search space on $n$ points,
+$\left(\mathbb{R}^2\right)^n$.
 This is the key idea that will allow us to transition from the finitely-verifiable statement ``\emph{no set of triple orientations over $n$ points satisfies property $\pi_k$}'' to the desired statement ``\emph{no set of $n$ points satisfies property $\pi_k$}.''
 
 \subsection{Properties of orientations}\label{sec:sigma-props}

--- a/ITP/triple-orientations.tex
+++ b/ITP/triple-orientations.tex
@@ -1,9 +1,24 @@
-An essential step for obtaining computational proofs of geometric results is \emph{discretization}: problems concerning the existence of an object $\mathcal{O}$ in a continuous space such as $\mathbb{R}^2$ must be reformulated in terms of the existence of a discrete and finitely representable object $\mathcal{O}'$ that a computer can find (or discard its existence).
-This poses a particular challenge for problems in which the desired geometric object $\mathcal{O}$ is characterized by very specific coordinates of points, requiring to deal with floating point arithmetic or numerical instability.
-Fortunately, this is not the case for Erd\H{o}s-Szekeres-type problems such as determining the value of $h(k)$, which are naturally well-suited for computation.
-This is so because the properties of interest (e.g., convexity, emptiness) can be described in terms of axiomatizable relationships between points and lines (e.g., point $p$ is above the line $\overrightarrow{qr}$, lines $\overrightarrow{qr}$ and $\overrightarrow{st}$ intersect, etc.), which are invariant under rotations, translations, and even small perturbations of the coordinates. This suggests the problems can be discretized in terms of boolean variables representing these relationships, forgetting the specific coordinates of the points.
-The combinatorial abstraction that has been most widely used in Erd\H{o}s-Szekeres-type problems is that of \emph{triple orientations}~\cite{ emptyHexagonNumber, scheucherTwoDisjoint5holes2020}. This concept is also known as \emph{signotopes}~\cite{felsnerSweepsArrangementsSignotopes2001,subercaseaux2023minimizing},  Knuth's \emph{counterclockwise} relation~\cite{knuthAxiomsHulls1992}, or \emph{signatures}~\cite{szekeres_peters_2006}.
-Given points $p, q, r$, their \emph{triple-orientation} is defined as
+To use computers to solve geometry problems,
+we often need to \emph{discretize} the search space first.
+In many cases,
+we reformulate the existence of an object~$\mathcal{O}$ in a continuous search space (such as $\mathbb{R}^2$)
+in terms of the existence of a discrete, finitely-representable object~$\mathcal{O}'$.
+Discretization is especially useful for geometry problems because the objects of interest (points and lines) otherwise would require the computer to use floating-point arithmetic,
+which suffers from numerical instability and problems of precision and finite representation.
+
+Fortunately,
+the properties used in Erd\H{o}s-Szekeres-type problems,
+and in $h(k)$ in particular,
+can be described in terms of axiomatizable relationships between points and lines
+that are invariant under rotation, translation, and even small perturbations of the points.
+We can represent these relationships with boolean variables,
+thus making us agnostic to the specific coordinates of the points.
+The most widely used combinatorial abstraction used for these kinds of problems is that of \emph{triple orientations}~\cite{ emptyHexagonNumber, scheucherTwoDisjoint5holes2020},
+which are also known as \emph{signotopes}~\cite{felsnerSweepsArrangementsSignotopes2001,subercaseaux2023minimizing},
+Knuth's \emph{counterclockwise} relation~\cite{knuthAxiomsHulls1992},
+or \emph{signatures}~\cite{szekeres_peters_2006}.
+An example is illustrated in~\Cref{fig:triple-orientation}.
+Given points $p, q, r$, their \emph{triple-orientation} is defined as:
 \newcommand{\sign}{\operatorname{sign}}
 \[
   \sigma(p, q, r) = \sign \det \begin{pmatrix} p_x & q_x & r_x \\ p_y & q_y & r_y \\ 1 & 1 & 1 \end{pmatrix} = \begin{cases}
@@ -43,7 +58,8 @@ Given points $p, q, r$, their \emph{triple-orientation} is defined as
 \caption{Illustration of triple orientations, where $\sigma(p, r, q) = -1, \sigma(r, s, q) = 1, $ and $\sigma(p, s, t) = 0$.}\label{fig:triple-orientation}
 \end{figure}
 
-An example is illustrated in~\Cref{fig:triple-orientation}. We directly use \textsf{mathlib}'s definition of the determinant to define $\sigma$.
+
+We define $\sigma$ in Lean using \textsf{mathlib}'s definition of the determinant.
 % @[pp_dot] abbrev x (p : Point) : ℝ := p 0
 % @[pp_dot] abbrev y (p : Point) : ℝ := p 1
 \begin{lstlisting}
@@ -141,14 +157,22 @@ Which in combination with \lstinline|theorem σHasEmptyKGon_iff_HasEmptyKGon|, p
 theorem OrientationProperty_HasEmptyKGon : OrientationProperty (HasEmptyKGon n)
 \end{lstlisting}
 
-Let us discuss why the previous theorem is relevant, as it plays an important role in the formalization of Erd\H{o}s-Szekeres-type problems. This boils down to two reasons:
-\begin{enumerate}
-  \item If we prove that the function $\sigma$ is invariant under a certain transformation of its arguments (e.g., rotations, translations, etc.) then we can directly conclude that any orientation property is invariant under the same transformation. This is a powerful tool for applying manipulations to pointsets that preserve the properties of interest, which will be key for symmetry breaking (see~\Cref{sec:symmetry-breaking}).
-    For a concrete example, consider a proof of an Erd\H{o}s-Szekeres-type result that starts by saying \emph{``we assume without loss of generality that points $p_1, \ldots, p_n$ all have positive $y$-coordinates''}.
-    As translations are $\sigma$-equivalences, we can see that this assumption
-    indeed does not impact the truth of any orientation property.
-  \item As introduced at the beginning of this section, SAT encodings for Erd\H{o}s-Szekeres-type problems are based on capturing properties like convexity or emptiness in terms of triple orientations, thus reducing a continuous search space to a discrete one. Because we have proved that $\pi_k(S)$ is an orientation property, the values of $\sigma$ for all triples of points in $S$ contain enough information to determine whether $\pi_k(S)$ or not.  Therefore, we have proved that given $n$ points it is enough to analyze the values of $\sigma$ over these points, a discrete space with at most $2^{n^3}$ possibilities, instead of $\left(\mathbb{R}^2\right)^n$. This is the key idea that will allow us to transition from the finitely-verifiable statement \emph{``no set of triple orientations over $n$ points satisfies property $\pi_k$''} to \emph{``no set of $n$ points satisfies property $\pi_k$''}.
-\end{enumerate}
+The previous theorem is important for two reasons.
+First, if $\sigma$ is invariant under certain point transformations (e.g., rotations, translations, etc.), then any orientation property is invariant under the same transformations.
+Identifying these transformations allows us to perform symmetry breaking to simplify the search space while preserving the property of interest (see~\Cref{sec:symmetry-breaking}).
+For a concrete example, consider a proof of an Erd\H{o}s-Szekeres-type result that starts by saying ``\emph{we assume without loss of generality that points $p_1, \ldots, p_n$ all have positive $y$-coordinates}.''
+Since $\sigma$ is invariant under translation, we can see that this assumption indeed does not impact the validity of the proof.
+
+Second,
+as introduced at the beginning of this section,
+SAT encodings for Erd\H{o}s-Szekeres-type problems use triple orientations to capture properties like convexity or emptiness,
+thus discretizing the problem.
+Because we have proved that $\pi_k(S)$ is an orientation property,
+we find that the values of $\sigma$ for all triples of points in $S$ contain enough information to determine whether $\pi_k(S)$.
+Therefore,
+we may analyze the values of $\sigma$ for the point triples in $S$, a discrete space with at most $2^{n^3}$ possibilities,
+instead of grappling with a continuous search space on $n$ points, $\left(\mathbb{R}^2\right)^n$.
+This is the key idea that will allow us to transition from the finitely-verifiable statement ``\emph{no set of triple orientations over $n$ points satisfies property $\pi_k$}'' to the desired statement ``\emph{no set of $n$ points satisfies property $\pi_k$}.''
 
 \subsection{Properties of orientations}\label{sec:sigma-props}
 


### PR DESCRIPTION
While the branch name is a bit of a misnomer, this PR tightens up a fair bit of prose without (hopefully) removing any ideas in the text. The changelog of edits are as follows.

Abstract:
- Reworded "With a combination of..." in second sentence.
- "Erdos-Szekeres-type problems" -> "similar problems" since the proper nouns were not introduced in the abstract.
- Simplified ending sentence.

Section 1 (Intro):
- Tightened up prose in second paragraph
  - Swapped order of ideas to emphasize that the "reduction step is not as trustworthy"
- Tightened up prose in "Verification of SAT proofs" paragraph.
  - Starting sentence shortened to "makes it trustworthy."
  - Shorten edsentence following "the reduction step has not received similar scrutiny," and making it a dependent clause.
  - Final two sentences of Maric paragraph shorter.

Section 4 (triple orientations):
- Tightened prose in first paragraph, split into two.
- Final two paragraphs placed into prose instead of an \begin{itemize} and tightened up.
- Reviewer comment about the remark of $(\mathbb{R}^2)^n$ addressed with explanatory prose.