### PR TITLE
Match hole_6_theorem with paper

### DIFF
--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -16,7 +16,7 @@ def ConvexIndep (S : Set Point) : Prop :=
 def ConvexEmptyIn (S P : Set Point) : Prop :=
     ConvexIndep S ∧ EmptyShapeIn S P
 
-/-- `HasEmptyKGon k P' means that `P' has a convex `k'-gon in `P' -/
+/-- `HasEmptyKGon k P' means that `P' has a convex, empty `k'-gon -/
 def HasEmptyKGon (k : Nat) (P : Set Point) : Prop :=
     ∃ S : Finset Point, S.card = k ∧ ↑S ⊆ P ∧ ConvexEmptyIn S P
 \end{lstlisting}

--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -12,9 +12,11 @@ i.e., the point set encloses a convex polygon. -/
 def ConvexIndep (S : Set Point) : Prop :=
     ∀ a ∈ S, a ∉ convexHull ℝ (S \ {a})
 
+/-- `ConvexEmptyIn S P' means that `S' forms a convex empty polygon in `P' -/
 def ConvexEmptyIn (S P : Set Point) : Prop :=
     ConvexIndep S ∧ EmptyShapeIn S P
 
+/-- `HasEmptyKGon k P' means that `P' has a convex `k'-gon in `P' -/
 def HasEmptyKGon (k : Nat) (S : Set Point) : Prop :=
     ∃ s : Finset Point, s.card = k ∧ ↑s ⊆ S ∧ ConvexEmptyIn s S
 \end{lstlisting}

--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -17,8 +17,8 @@ def ConvexEmptyIn (S P : Set Point) : Prop :=
     ConvexIndep S ∧ EmptyShapeIn S P
 
 /-- `HasEmptyKGon k P' means that `P' has a convex `k'-gon in `P' -/
-def HasEmptyKGon (k : Nat) (S : Set Point) : Prop :=
-    ∃ s : Finset Point, s.card = k ∧ ↑s ⊆ S ∧ ConvexEmptyIn s S
+def HasEmptyKGon (k : Nat) (P : Set Point) : Prop :=
+    ∃ S : Finset Point, S.card = k ∧ ↑S ⊆ P ∧ ConvexEmptyIn S P
 \end{lstlisting}
 
 Let \lstinline|SetInGenPos| be a predicate that states that a set of points is in \emph{general position}, i.e., no three points lie on a common line (made precise in~\Cref{sec:triple-orientations}).

--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -26,7 +26,7 @@ With this we can already state the core theorem.
 
 \begin{lstlisting}
 theorem hole_6_theorem : ∀ (pts : Finset Point),
-    Point.SetInGenPos pts → pts.card = 30 → HasEmptyKGon 6 pts
+    SetInGenPos pts → pts.card = 30 → HasEmptyKGon 6 pts
 \end{lstlisting}
 
 At the root  of the encoding of Heule and Scheucher is the idea that

--- a/ITP/geometry.tex
+++ b/ITP/geometry.tex
@@ -19,15 +19,20 @@ def HasEmptyKGon (k : Nat) (S : Set Point) : Prop :=
     ∃ s : Finset Point, s.card = k ∧ ↑s ⊆ S ∧ ConvexEmptyIn s S
 \end{lstlisting}
 
-Let \lstinline|ListInGenPos| be a predicate that states that a list of points is in \emph{general position}, i.e., no three points lie on a common line (made precise in~\Cref{sec:triple-orientations}).
-With this we can already state the main theorem of our paper.
+Let \lstinline|SetInGenPos| be a predicate that states that a set of points is in \emph{general position}, i.e., no three points lie on a common line (made precise in~\Cref{sec:triple-orientations}).
+With this we can already state the core theorem.
 
 \begin{lstlisting}
-theorem hole_6_theorem (pts : List Point) (gp : ListInGenPos pts)
-    (h : pts.length ≥ 30) : HasEmptyKGon 6 pts.toFinset
+theorem hole_6_theorem : ∀ (pts : Finset Point),
+    Point.SetInGenPos pts → pts.card = 30 → HasEmptyKGon 6 pts
 \end{lstlisting}
 
-At the root  of the encoding of Heule and Scheucher is the idea that the~\lstinline|ConvexEmptyIn| predicate can be determined by analyzing only triangles. In particular, that a set $s$ of $k$ points in a pointset $S$ form an empty convex $k$-gon if and only if all the ${k \choose 3}$ triangles induced by vertices in $s$ are empty with respect to $S$. This is discussed informally in~\cite[Section 3, Eq.~4]{emptyHexagonNumber}.
+At the root  of the encoding of Heule and Scheucher is the idea that
+the~\lstinline|ConvexEmptyIn| predicate can be determined by analyzing only triangles.
+In particular, that a set $s$ of $k$ points in a pointset $S$ form an empty convex $k$-gon
+if and only if all the ${k \choose 3}$ triangles induced by vertices in $s$
+are empty with respect to $S$.
+This is discussed informally in~\cite[Section 3, Eq.~4]{emptyHexagonNumber}.
 Concretely, we prove the following theorem:
 \begin{lstlisting}
 theorem ConvexEmptyIn.iff_triangles {s : Finset Point} {S : Set Point}

--- a/ITP/intro.tex
+++ b/ITP/intro.tex
@@ -89,7 +89,7 @@ In this spirit, we connect our results to~\textsf{mathlib} as much as possible.
 In the 1930s,
 Erd\H{o}s and Szekeres, inspired by Esther Klein, showed that for any $k \geq 3$,
 one can find a sufficiently large number $n$
-such that every $n$ points in \emph{general position}
+such that every $n$ points in the plane in \emph{general position}
 (i.e., with no three points collinear)
 contain a convex \emph{$k$-gon}, i.e., a convex polygon with $k$ vertices~\cite{35erdos_combinatorial_problem_geometry}.
 The minimal such $n$ is denoted $g(k)$.

--- a/ITP/related-work.tex
+++ b/ITP/related-work.tex
@@ -13,7 +13,7 @@ of determining $k$-hole numbers $h(k)$.
 Rather than devise a new SAT encoding,
 we use essentially the same encoding presented by Heule and Scheucher~\cite{emptyHexagonNumber}.
 Interestingly,
-a (verified) proof of $g(6) \leq 17$ can be obtained
+a formal proof of $g(6) \leq 17$ can be obtained
 as a corollary of our development.
 We can assert the hole variables $\hvar_{a,b,c}$ as true
 while leaving the remainder of the encoding in~\Cref{fig:full-encoding} unchanged,
@@ -29,8 +29,8 @@ with no convex $6$-gon.
 We checked this formula to be unsatisfiable for $n = 17$,
 giving the same result as Marić:
 \begin{lstlisting}
-theorem gon_6_theorem (pts : List Point) (gp : ListInGenPos pts)
-    (h : pts.length ≥ 17) : HasConvexKGon 6 pts.toFinset
+theorem gon_6_theorem : ∀ (pts : Finset Point),
+  SetInGenPos pts → pts.card = 17 → HasConvexKGon 6 pts
 \end{lstlisting}
 
 Since both formalizations can be executed,

--- a/ITP/symmetry-breaking.tex
+++ b/ITP/symmetry-breaking.tex
@@ -30,16 +30,20 @@ Second, the CCW-order property breaks symmetry due to \emph{rotation} by fixing 
 \input{fig-sigma-equiv}
 
 Third, the lex-order property breaks symmetry due to \emph{reflection}.
-Reflecting a set of points~$S$ through a line (e.g., with the map $(x, y) \mapsto (-x, y)$)
+Reflecting a set of points~$S$ over a line (e.g., with the map $(x, y) \mapsto (-x, y)$)
 preserves the presence of $k$-holes and convex $k$-gons.
-Such reflected point sets are almost $\sigma$-equivalent to $S$,
-but their orientations have all changed sign.
-Consider the point sets in \Cref{fig:sigma-equiv}.
-As a result,
-we included the \emph{parity} flag in our Lean definition of $\sigma$-equivalence
-to capture changes in orientations due to reflection,
-where \lstinline|parity := true| changes sign of all orientations.
-The lex-order property ensures that the point set is the lexicographically-larger reflection.
+This operation does not quite preserve orientations, but rather flips them
+(clockwise orientations become counterclockwise and vice versa).
+Our definition of $\sigma$-equivalence includes a \emph{parity} flag for this purpose:
+\lstinline|parity := false| corresponds to the case that orientations are the same,
+and \lstinline|parity := true| corresponds to the case that all orientations have been flipped.
+See the point sets in \Cref{fig:sigma-equiv} for an example.
+
+The lex-order property, then, picks between a set of points and its reflection over \(x=0\).
+The vector of consecutive orientations from the middle to the left
+is assumed to be at least as big as the vector of consecutive orientations from the middle to the right.
+This constraint is not geometrically meaningful,
+but is easy to implement in the SAT encoding.
 
 We prove that there always exists a $\sigma$-equivalent point set in canonical position.
 

--- a/ITP/symmetry-breaking.tex
+++ b/ITP/symmetry-breaking.tex
@@ -130,15 +130,3 @@ if $1 < i < j \leq n$ are indices, then
 \end{align*}
 This concludes the proof.
 \end{proof}
-
-We had quite some difficulty formalizing the symmetry-breaking argument.
-We spent many hours around a whiteboard,
-simplifying the argument to minimize the amount of theory we would need to develop.
-The projective transformation in Step 3 was particularly difficult to wrangle.
-This step, and those after it, requires careful bookkeeping around the distinguished point $p_1$.
-
-Once these details were worked out,
-the proof was relatively straightforward, albeit long and tedious.
-Each step of the proof justifies not only that a new property is achieved,
-but also that all properties from previous steps are preserved.
-As a result, the proof burden was substantial.

--- a/ITP/symmetry-breaking.tex
+++ b/ITP/symmetry-breaking.tex
@@ -58,14 +58,32 @@ theorem symmetry_breaking : ListInGenPos l →
 
 
 \begin{proof}[Proof Sketch]
-The proof proceeds in 6 steps, illustrated in~\Cref{fig:symmetry-breaking}. In each of the steps, we will construct a new list of points that is $\sigma$-equivalent to the previous one, and the last one will be in canonical position.\footnote{Even though we defined $\sigma$-equivalence for sets of points, our formalization goes back and forth between sets and lists. Given that symmetry breaking distinguishes between the order of the points e.g., $x$-order, this proof proceeds over lists. All permutations of a list are immediately $\sigma$-equivalent.}
-The main justification for each step is that, given that the function $\sigma$ is defined as a sign of the determinant, applying transformations that preserve (or, when \lstinline|parity := true|, uniformly reverse) the sign of the determinant will preserve (or uniformly reverse) the values of $\sigma$. In particular, given the identity $\det(AB) = \det(A)\det(B)$, if we apply a transformation to the points that corresponds to multiplying by a matrix $B$ such that $\det(B) > 0$, then $\sign(\det(A)) = \sign(\det(AB))$, and thus orientations will be preserved.
-In step 1, we transform the list of points so that no two points share the same $x$-coordinate. This can be done by applying a rotation to the list of points, which corresponds to multiplying by a rotation matrix.
-Rotations always have determinant $1$. 
-In step 2, we translate all points by a constant vector $t$, by multiplying by a translation matrix, so that the left most point gets position $(0, 0)$, and naturally every other point will have a positive $x$-coordinate.
-Let $L_2$ be the list of points after this transformation, excluding $(0,0)$ which we will denote by $p_1$.
-Then, in step 3, we  apply the projective transformation $f: (x, y) \mapsto (y/x, 1/x)$ to every point in $L_2$, showing that this preserves orientations within $L_2$.
-To see that this mapping is a $\sigma$-equivalence consider that 
+The proof proceeds in 6 steps, illustrated in~\Cref{fig:symmetry-breaking}.
+In each of the steps, we will construct a new list of points that is $\sigma$-equivalent to the previous one,
+and the last one will be in canonical position.
+\footnote{Even though we defined $\sigma$-equivalence for sets of points,
+our formalization goes back and forth between sets and lists.
+Given that symmetry breaking distinguishes between the order of the points
+e.g., $x$-order, this proof proceeds over lists.
+All permutations of a list are immediately $\sigma$-equivalent.}
+The main justification for each step is that,
+given that the function $\sigma$ is defined as a sign of the determinant,
+applying transformations that preserve (or, when \lstinline|parity := true|, uniformly reverse)
+the sign of the determinant will preserve (or uniformly reverse) the values of $\sigma$.
+
+For example, given the identity $\det(AB) = \det(A)\det(B)$,
+if we apply a transformation to the points that corresponds to multiplying by a matrix $B$ such that $\det(B) > 0$,
+then $\sign(\det(A)) = \sign(\det(AB))$, and thus orientations will be preserved.
+\textbf{Step 1}: we transform the list of points so that no two points share the same $x$-coordinate.
+This can be done by applying a rotation to the list of points, which corresponds to multiplying by a rotation matrix.
+Rotations always have determinant $1$.
+\textbf{Step 2}: we translate all points by a constant vector $t$, by multiplying by a translation matrix,
+so that the left most point gets position $(0, 0)$, and naturally every other point will have a positive $x$-coordinate.
+
+Let $L_2$ be the list of points after Step 2, excluding $(0,0)$ which we will denote by $p_1$.
+\textbf{Step 3}: we apply the projective transformation $f: (x, y) \mapsto (y/x, 1/x)$ to every point in $L_2$,
+showing that this preserves orientations within $L_2$.
+To see that this mapping is a $\sigma$-equivalence consider that
 \[
 \begin{multlined}
  \sign \det \begin{pmatrix} p_x & q_x & r_x \\ p_y & q_y & r_y \\ 1 & 1 & 1 \end{pmatrix} =  \sign \det \left( \begin{pmatrix} 0 & 0 & 1 \\ 1 & 0 & 0\\ 0 & 1 & 0 \end{pmatrix}  \begin{pmatrix} \nicefrac{p_y}{p_x} & \nicefrac{q_y}{q_x} & \nicefrac{r_y}{r_x} \\ \nicefrac{1}{p_x} & \nicefrac{1}{q_x} & \nicefrac{1}{r_x} \\ 1 & 1 & 1 \end{pmatrix}  \begin{pmatrix} p_x & 0 & 0 \\ 0 & q_x & 0\\ 0 & 0 & r_x \end{pmatrix} \right)\\
@@ -73,7 +91,8 @@ To see that this mapping is a $\sigma$-equivalence consider that
                         %  \tag{As $p_x q_x r_x > 0$ by step 2}
 \end{multlined}
 \]
-To preserve orientations with respect to the leftmost point $(0, 0)$, we set $f( (0, 0)) = (0, \infty)$, a special point that is treated separately as follows.
+To preserve orientations with respect to the leftmost point $(0, 0)$, we set $f( (0, 0)) = (0, \infty)$,
+a special point that is treated separately as follows.
 As the function $\sigma$ takes points in $\mathbb{R}^2$ as arguments,
 we need to define an extension
 \(
@@ -83,13 +102,25 @@ we need to define an extension
   \end{cases},
 \)
 We then show that $\sigma((0, 0), q, r) = \sigma_{(0, \infty)}(f(q), f(r))$ for all points $q, r \in L_2$. 
-In step 4, we sort the list $L_2$ by $x$-coordinate in increasing order, thus obtaining a list $L_3$.
-This can be done while preserving $\sigma$-equivalence because sorting corresponds to a permutation, and all permutations of a list are $\sigma$-equivalent by definition.
-In step 5, we check whether the \textsf{Lex order} condition above is satisfied in $L_3$, and if it is not, we reflect the pointset, which preserves $\sigma$-equivalence with \lstinline|parity := true|.
+
+\textbf{Step 4}: we sort the list $L_2$ by $x$-coordinate in increasing order,
+thus obtaining a list $L_3$.
+This can be done while preserving $\sigma$-equivalence because sorting corresponds to a permutation,
+and all permutations of a list are $\sigma$-equivalent by definition.
+\textbf{Step 5}: we check whether the \textsf{Lex order} condition above is satisfied in $L_3$,
+and if it is not, we reflect the pointset,
+which preserves $\sigma$-equivalence with \lstinline|parity := true|.
 Note that in such a case we need to relabel the points from left to right again.
-In step 6, we bring point $(0, \infty)$ back into the range by first finding a constant $c$ such that all points in $L_3$ are to the right of the line $y=c$, and then finding a large enough value $M$ such that $(c, M)$ has the same orientation with respect to the other points as $(0, \infty)$ did, meaning that 
+
+\textbf{Step 6}: we bring point $(0, \infty)$ back into the range
+by first finding a constant $c$ such that all points in $L_3$ are to the right of the line $y=c$,
+and then finding a large enough value $M$ such that $(c, M)$ has the same orientation
+with respect to the other points as $(0, \infty)$ did,
+meaning that 
 \(\sigma((c, M), q, r) = \sigma_{(0, \infty)}(q, r)\) for every $q, r \in L_3$.
-Finally, we note that the list of points obtained in step 6 satisfies the \text{CCW-order} property by the following reasoning:
+
+Finally, we note that the list of points obtained in step 6
+satisfies the \text{CCW-order} property by the following reasoning:
 if $1 < i < j \leq n$ are indices, then 
 \begin{align*}
   \sigma(p_1, p_i, p_j) = 1 &\iff \sigma((c, M), p_i, p_j) = 1\\
@@ -100,3 +131,14 @@ if $1 < i < j \leq n$ are indices, then
 This concludes the proof.
 \end{proof}
 
+We had quite some difficulty formalizing the symmetry-breaking argument.
+We spent many hours around a whiteboard,
+simplifying the argument to minimize the amount of theory we would need to develop.
+The projective transformation in Step 3 was particularly difficult to wrangle.
+This step, and those after it, requires careful bookkeeping around the distinguished point $p_1$.
+
+Once these details were worked out,
+the proof was relatively straightforward, albeit long and tedious.
+Each step of the proof justifies not only that a new property is achieved,
+but also that all properties from previous steps are preserved.
+As a result, the proof burden was substantial.

--- a/ITP/symmetry-breaking.tex
+++ b/ITP/symmetry-breaking.tex
@@ -59,9 +59,9 @@ theorem symmetry_breaking : ListInGenPos l →
 
 \begin{proof}[Proof Sketch]
 The proof proceeds in 6 steps, illustrated in~\Cref{fig:symmetry-breaking}.
-In each of the steps, we will construct a new list of points that is $\sigma$-equivalent to the previous one,
-and the last one will be in canonical position.
-\footnote{Even though we defined $\sigma$-equivalence for sets of points,
+In each of the steps, we construct a new list of points that is $\sigma$-equivalent to the previous one,
+with the last one being in canonical position.\footnote{
+Even though we defined $\sigma$-equivalence for sets of points,
 our formalization goes back and forth between sets and lists.
 Given that symmetry breaking distinguishes between the order of the points
 e.g., $x$-order, this proof proceeds over lists.
@@ -77,10 +77,11 @@ then $\sign(\det(A)) = \sign(\det(AB))$, and thus orientations will be preserved
 \textbf{Step 1}: we transform the list of points so that no two points share the same $x$-coordinate.
 This can be done by applying a rotation to the list of points, which corresponds to multiplying by a rotation matrix.
 Rotations always have determinant $1$.
-\textbf{Step 2}: we translate all points by a constant vector $t$, by multiplying by a translation matrix,
-so that the left most point gets position $(0, 0)$, and naturally every other point will have a positive $x$-coordinate.
+\textbf{Step 2}: we translate all points by a constant vector $t$, which corresponds to multiplying by a translation matrix,
+to bring the leftmost point~$p_1$ to position $(0, 0)$.
+As a result, every other point has a positive $x$-coordinate.
 
-Let $L_2$ be the list of points after Step 2, excluding $(0,0)$ which we will denote by $p_1$.
+Let $L_2$ be the list of points excluding $p_1$ after Step 2.
 \textbf{Step 3}: we apply the projective transformation $f: (x, y) \mapsto (y/x, 1/x)$ to every point in $L_2$,
 showing that this preserves orientations within $L_2$.
 To see that this mapping is a $\sigma$-equivalence consider that
@@ -103,8 +104,8 @@ we need to define an extension
 \)
 We then show that $\sigma((0, 0), q, r) = \sigma_{(0, \infty)}(f(q), f(r))$ for all points $q, r \in L_2$. 
 
-\textbf{Step 4}: we sort the list $L_2$ by $x$-coordinate in increasing order,
-thus obtaining a list $L_3$.
+\textbf{Step 4}: we sort the list~$L_2$ by $x$-coordinate in increasing order,
+thus obtaining a list~$L_3$.
 This can be done while preserving $\sigma$-equivalence because sorting corresponds to a permutation,
 and all permutations of a list are $\sigma$-equivalent by definition.
 \textbf{Step 5}: we check whether the \textsf{Lex order} condition above is satisfied in $L_3$,

--- a/ITP/triple-orientations.tex
+++ b/ITP/triple-orientations.tex
@@ -189,17 +189,17 @@ def σHasEmptyKGon (n : Nat) (S : Set Point) : Prop :=
   ∃ s : Finset Point, s.card = n ∧ ↑s ⊆ S ∧ ∀ (a ∈ s) (b ∈ s) (c ∈ s), 
   a ≠ b → a ≠ c → b ≠ c → σIsEmptyTriangleFor a b c S
 
-theorem σHasEmptyKGon_iff_HasEmptyKGon (gp : ListInGenPos pts) :
-      σHasEmptyKGon n pts.toFinset ↔ HasEmptyKGon n pts.toFinset
+theorem σHasEmptyKGon_iff_HasEmptyKGon {n : Nat} (gp : ListInGenPos pts) :
+    σHasEmptyKGon n pts.toFinset ↔ HasEmptyKGon n pts.toFinset
 \end{lstlisting}
 
 Then, because \lstinline|σHasEmptyKGon| is ultimately defined in terms of $\sigma$, we can prove
 \begin{lstlisting}
-lemma OrientationProperty_σHasEmptyKGon : OrientationProperty (σHasEmptyKGon n)
+lemma OrientationProperty_σHasEmptyKGon {n : Nat} : OrientationProperty (σHasEmptyKGon n)
 \end{lstlisting}
 Which in combination with \lstinline|theorem σHasEmptyKGon_iff_HasEmptyKGon|, provides
 \begin{lstlisting}
-theorem OrientationProperty_HasEmptyKGon : OrientationProperty (HasEmptyKGon n)
+theorem OrientationProperty_HasEmptyKGon {n : Nat} : OrientationProperty (HasEmptyKGon n)
 \end{lstlisting}
 
 The previous theorem is important for two reasons.
@@ -244,15 +244,25 @@ theorem σ_prop₃ (h : Sorted₄ p q r s) (gp : InGenPos₄ p q r s) :
     σ p q r = cw → σ q r s = cw → σ p r s = cw
 \end{lstlisting}
 
-They will be used in justifying the addition of clauses~\labelcref{eq:signotopeClauses11,eq:signotopeClauses12};
-clauses like these or the one below are easily added,
-and are commonly used to reduce the search space in SAT encodings~\cite{emptyHexagonNumber,scheucherTwoDisjoint5holes2020,subercaseaux2023minimizing, szekeres_peters_2006}.
+Our proofs of these properties are based on an equivalence between
+the orientation of a triple of points
+and the \emph{slopes} of the lines that connect them.
+Namely, if $p, q, r$  are sorted from left to right,
+then (i) $\sigma(p,q,r)=1 \iff \textsf{slope}(\overrightarrow{pq}) < \textsf{slope}(\overrightarrow{pr})$
+and (ii) $\sigma(p,q,r)=1 \iff \textsf{slope}(\overrightarrow{pr}) < \textsf{slope}(\overrightarrow{qr})$.
+By first proving these \emph{slope-orientation} equivalences
+we can then easily prove \lstinline|σ_prop₁| and others,
+as illustrated in~\Cref{fig:orientation-implication}.
 
-\begin{align}
-  &\left(\neg \orvar_{a, b, c} \lor \neg \orvar_{a, c, d} \lor \orvar_{a, b, d}\right) \land \left(\orvar_{a, b, c} \lor \orvar_{a, c, d} \lor  \neg \orvar_{a, b, d}\right)
-\end{align}
+These properties will be used in~\Cref{sec:encoding}
+to justify clauses~\labelcref{eq:signotopeClauses11,eq:signotopeClauses12} of the SAT encoding;
+these clauses are commonly added in orientation-based SAT encodings
+to reduce the search space by removing some ``unrealizable'' orientations~\cite{emptyHexagonNumber,scheucherTwoDisjoint5holes2020,subercaseaux2023minimizing, szekeres_peters_2006}.
+\[
+  \left(\neg \orvar_{a, b, c} \lor \neg \orvar_{a, c, d} \lor \orvar_{a, b, d}\right) \land
+  \left(\orvar_{a, b, c} \lor \orvar_{a, c, d} \lor  \neg \orvar_{a, b, d}\right)
+\]
 
-Our proofs of these properties are based on an equivalence between the orientation of a triple of points and the \emph{slopes} of the lines that connect them. Namely, if $p, q, r$  are sorted from left to right, then (i) $\sigma(p,q,r)=1 \iff \textsf{slope}(\overrightarrow{pq}) < \textsf{slope}(\overrightarrow{pr})$  and (ii) $\sigma(p,q,r)=1 \iff \textsf{slope}(\overrightarrow{pr}) < \textsf{slope}(\overrightarrow{qr})$. By first proving these \emph{slope-orientation} equivalences we can then easily prove \lstinline|σ_prop₁| and others, as illustrated in~\Cref{fig:orientation-implication}.
 
 \begin{figure}
   \centering

--- a/ITP/triple-orientations.tex
+++ b/ITP/triple-orientations.tex
@@ -128,12 +128,17 @@ Furthermore, we can start formalizing sets of points that are \emph{equivalent} 
 structure σEquiv (S T : Set Point) where
   f : Point → Point
   bij : Set.BijOn f S T
-  parity : Bool -- See Section 4 for details on this field
+  parity : Bool
   σ_eq : ∀ (p ∈ S) (q ∈ S) (r ∈ S), σ p q r = parity ^^^ σ (f p) (f q) (f r)
 
 def OrientationProperty (P : Set Point → Prop) :=
   ∀ {{S T}}, S ≃σ T → P S → P T -- `≃σ` is infix notation for `σEquiv`
 \end{lstlisting}
+
+Our notion of \(\sigma\) equivalence allows for all orientations to be flipped.
+The \lstinline{^^^} (xor) operation does nothing when \lstinline{parity} is false,
+and negates the orientation when \lstinline{parity} is true.
+See~\Cref{sec:symmetry-breaking} for more details.
 
 To illustrate how these notions will be used, let us consider the property
 \(

--- a/Lean/Geo.lean
+++ b/Lean/Geo.lean
@@ -19,11 +19,11 @@ i.e. the point set encloses a convex polygon. Also known as a "convex-independen
 recall Geo.ConvexIndep (S : Set Point) : Prop :=
   ∀ a ∈ S, a ∉ convexHull ℝ (S \ {a})
 
-recall Geo.HasConvexKGon (n : Nat) (S : Set Point) : Prop :=
-  ∃ s : Finset Point, s.card = n ∧ ↑s ⊆ S ∧ ConvexIndep s
+recall Geo.HasConvexKGon (n : Nat) (P : Set Point) : Prop :=
+  ∃ S : Finset Point, S.card = n ∧ ↑S ⊆ P ∧ ConvexIndep S
 
-recall Geo.HasEmptyKGon (n : Nat) (S : Set Point) : Prop :=
-  ∃ s : Finset Point, s.card = n ∧ ↑s ⊆ S ∧ ConvexIndep s ∧ EmptyShapeIn s S
+recall Geo.HasEmptyKGon (n : Nat) (P : Set Point) : Prop :=
+  ∃ S : Finset Point, S.card = n ∧ ↑S ⊆ P ∧ ConvexIndep S ∧ EmptyShapeIn S P
 
 /- `gonNumber k` is the smallest number `n` such that every set of `n` or more points
 in general position contains a convex-independent set of size `k`. -/

--- a/Lean/Geo.lean
+++ b/Lean/Geo.lean
@@ -98,7 +98,7 @@ axiom unsat_6hole_cnf : (Geo.hexagonCNF (rlen := 30-1) (holes := true)).isUnsat
 (and no fewer) contains an empty hexagon.
 -/
 theorem holeNumber_6 : holeNumber 6 = 30 :=
-  le_antisymm (hole_6_theorem unsat_6hole_cnf) (hole_lower_bound [
+  le_antisymm (hole_6_theorem' unsat_6hole_cnf) (hole_lower_bound [
     (1, 1260), (16, 743), (22, 531), (37, 0), (306, 592), (310, 531), (366, 552), (371, 487),
     (374, 525), (392, 575), (396, 613), (410, 539), (416, 550), (426, 526), (434, 552), (436, 535),
     (446, 565), (449, 518), (450, 498), (453, 542), (458, 526), (489, 537), (492, 502), (496, 579),

--- a/Lean/Geo/Canonicalization/SymmetryBreaking.lean
+++ b/Lean/Geo/Canonicalization/SymmetryBreaking.lean
@@ -150,7 +150,7 @@ theorem HasEmptyKGon_extension' :
     (∀ l : List Point, l.length = n → l.Nodup → Point.ListInGenPos l → HasEmptyKGon k l.toFinset) →
     l.Nodup → n ≤ l.length → HasEmptyKGon k l.toFinset := by
   intro H nodup llength
-  rw [← σHasEmptyKGon_iff_HasEmptyKGon gp]
+  rw [← σHasEmptyKGon_iff_HasEmptyKGon gp.toFinset]
 
   have ⟨l₁, σ₁, distinct⟩ := σEmbed_rotate l nodup
   replace gp := (OrientationProperty'.gp σ₁).mp gp
@@ -172,7 +172,7 @@ theorem HasEmptyKGon_extension' :
   suffices σHasEmptyKGon k l₂.toFinset by
     rwa [List.toFinset_eq_of_perm _ _ l₂l₁] at this
 
-  rw [σHasEmptyKGon_iff_HasEmptyKGon gp]
+  rw [σHasEmptyKGon_iff_HasEmptyKGon gp.toFinset]
   let left := l₂.take n
   let right := l₂.drop n
   have leftl₂ : left <+ l₂ := List.take_sublist ..

--- a/Lean/Geo/Definitions/OrientationProperties.lean
+++ b/Lean/Geo/Definitions/OrientationProperties.lean
@@ -67,14 +67,14 @@ theorem σIsEmptyTriangleFor_iff' {a b c : Point} (gp : Point.ListInGenPos S)
   have ss := hs.subset; have nd := hs.nodup (gp.nodup hs.length_le); simp [not_or] at ss nd
   rw [σIsEmptyTriangleFor_iff] <;> simp [*]
 
-theorem σHasEmptyKGon_iff_HasEmptyKGon (gp : Point.ListInGenPos pts) :
-    σHasEmptyKGon n pts.toFinset ↔ HasEmptyKGon n pts.toFinset := by
+theorem σHasEmptyKGon_iff_HasEmptyKGon {pts : Finset Point} (gp : Point.SetInGenPos ↑pts) :
+    σHasEmptyKGon n pts ↔ HasEmptyKGon n pts := by
   unfold σHasEmptyKGon HasEmptyKGon
   refine exists_congr fun s => and_congr_right' <| and_congr_right fun spts => ?_
   rw [ConvexEmptyIn.iff_triangles'' spts gp]
   simp [Set.subset_def] at spts
   iterate 9 refine forall_congr' fun _ => ?_
-  rw [σIsEmptyTriangleFor_iff gp] <;> simp [EmptyShapeIn, PtInTriangle, *]
+  rw [σIsEmptyTriangleFor_iff'' gp] <;> simp [EmptyShapeIn, PtInTriangle, *]
 
 theorem σHasConvexKGon_iff_HasConvexKGon (gp : Point.ListInGenPos pts) :
     σHasConvexKGon n pts.toFinset ↔ HasConvexKGon n pts.toFinset := by
@@ -228,7 +228,7 @@ theorem σCCWPoints.cycle (H : σCCWPoints (l₁ ++ l₂)) : σCCWPoints (l₂ +
     fun a ha => (H3 a ha).imp <| Eq.trans (by rw [σ_perm₂, ← σ_perm₁])⟩
 
 theorem σCCWPoints.convex (H : σCCWPoints l) : ConvexIndep l.toFinset := by
-  refine ((ConvexEmptyIn.iff_triangles'' subset_rfl H.gp).2 ?_).1
+  refine ((ConvexEmptyIn.iff_triangles'' subset_rfl H.gp.toFinset).2 ?_).1
   simp only [mem_toFinset, Finset.mem_sdiff, Finset.mem_insert, Finset.mem_singleton,
     not_or, and_imp]
   intro a ha b hb c hc ab ac bc p hp pa pb pc hn
@@ -353,7 +353,7 @@ theorem σCCWPoints.emptyHexagon
     gp ((@perm_append_comm _ [c,d,e,f] [a, b']).subperm.trans sp)
   have ⟨f', sp, H, efa⟩ := σCCWPoints.flatten (H.cycle (l₁ := [c, d']) (l₂ := [e,f,a,b']))
     gp ((@perm_append_comm _ [e,f,a,b'] [c, d']).subperm.trans sp)
-  refine (σHasEmptyKGon_iff_HasEmptyKGon gp).2
+  refine (σHasEmptyKGon_iff_HasEmptyKGon gp.toFinset).2
     ⟨[e, f', a, b', c, d'].toFinset, ?_, by simpa [Set.subset_def] using sp.subset, H.convex, ?_⟩
   · exact congrArg length (dedup_eq_self.2 (H.gp.nodup (by show 3 ≤ 6; decide)))
   · refine σCCWPoints.split_emptyShapeIn e [f'] a [b', c, d'] H efa ?_

--- a/Lean/Geo/Definitions/Structures.lean
+++ b/Lean/Geo/Definitions/Structures.lean
@@ -55,16 +55,18 @@ theorem ConvexIndep.lt_3 {s : Finset Point} (hs : s.card < 3) : ConvexIndep s :=
     subst eq; simp at hn; subst b
     simpa using congrArg (a ∈ ·) e1
 
-theorem ConvexIndep.triangle' {s : Finset Point} {S : List Point}
-    (hs : s.card ≤ 3) (sS : s ⊆ S.toFinset) (gp : Point.ListInGenPos S) :
+theorem ConvexIndep.triangle' {s : Finset Point} {S : Finset Point}
+    (hs : s.card ≤ 3) (sS : s ⊆ S) (gp : Point.SetInGenPos S) :
     ConvexIndep s := by
   cases lt_or_eq_of_le hs with
   | inl hs => exact ConvexIndep.lt_3 hs
   | inr hs =>
     match s, s.exists_mk with | _, ⟨[a,b,c], h1, rfl⟩ => ?_
     rw [ConvexIndep.triangle_iff]
-    apply Point.ListInGenPos.subperm.1 gp
-    exact List.subperm_of_subset h1 (by simpa [Finset.subset_iff] using sS)
+    refine gp ?_ h1
+    intro _ _
+    simp [Finset.subset_iff] at *
+    aesop
 
 theorem ConvexIndep.antitone {S₁ S₂ : Set Point} (S₁S₂ : S₁ ⊆ S₂)
     (convex : ConvexIndep S₂) : ConvexIndep S₁ := by
@@ -115,12 +117,12 @@ theorem ConvexEmptyIn.iff_triangles {s : Finset Point} {S : Set Point}
     refine this.2 _ ⟨pS, fun pu => ?_⟩ (convexHull_mono tu ht)
     exact this.1 p pu (convexHull_mono (Set.subset_diff_singleton tu (mt (tS' ·) pn)) ht)
 
-theorem ConvexEmptyIn.iff_triangles' {s : Finset Point} {S : List Point}
-    (sS : s ⊆ S.toFinset) (gp : Point.ListInGenPos S) :
-    ConvexEmptyIn s S.toFinset ↔
-    ∀ (t : Finset Point), t.card = 3 → t ⊆ s → EmptyShapeIn t S.toFinset := by
+theorem ConvexEmptyIn.iff_triangles' {s : Finset Point} {S : Finset Point}
+    (sS : s ⊆ S) (gp : Point.SetInGenPos S) :
+    ConvexEmptyIn s S ↔
+    ∀ (t : Finset Point), t.card = 3 → t ⊆ s → EmptyShapeIn t S := by
   if sz : 3 ≤ s.card then
-    have' sS' : (s:Set _) ⊆ S.toFinset := sS
+    have' sS' : (s:Set _) ⊆ S := sS
     rw [ConvexEmptyIn.iff_triangles sS' sz]
     simp (config := {contextual := true}) [ConvexEmptyIn,
       fun a b => ConvexIndep.triangle' a (subset_trans b sS) gp]
@@ -134,16 +136,17 @@ theorem ConvexEmptyIn.iff_triangles' {s : Finset Point} {S : List Point}
       | ⟨[a], _, (eq : s = {a})⟩, _ => subst eq; simpa using pS'
       | ⟨[a,b], h1, eq⟩, _ =>
         have : s = {a, b} := eq ▸ by ext; simp
-        have gp' := Point.ListInGenPos.subperm.1 gp <|
-          List.subperm_of_subset (.cons (a := p) (by simpa [this] using pn) h1) <|
-          List.cons_subset.2 ⟨by simpa using pS, by simpa [this, Finset.insert_subset_iff] using sS⟩
+        have gp' : Point.InGenPos₃ p a b := by
+          apply gp
+          · intro _ _; aesop
+          · aesop
         cases gp'.not_mem_seg (by simpa [this] using pS')
 
-theorem ConvexEmptyIn.iff_triangles'' {s : Finset Point} {S : List Point}
-    (sS : s ⊆ S.toFinset) (gp : Point.ListInGenPos S) :
-    ConvexEmptyIn s S.toFinset ↔
+theorem ConvexEmptyIn.iff_triangles'' {s : Finset Point} {S : Finset Point}
+    (sS : s ⊆ S) (gp : Point.SetInGenPos S) :
+    ConvexEmptyIn s S ↔
     ∀ᵉ (a ∈ s) (b ∈ s) (c ∈ s), a ≠ b → a ≠ c → b ≠ c →
-      ∀ p ∈ S.toFinset \ {a,b,c}, ¬PtInTriangle p a b c := by
+      ∀ p ∈ S \ {a,b,c}, ¬PtInTriangle p a b c := by
   simp_rw [iff_triangles' sS gp, Finset.card_eq_three, EmptyShapeIn, PtInTriangle]
   constructor
   . intro H a ha b hb c hc ab ac bc p hp
@@ -165,20 +168,15 @@ theorem ConvexEmptyIn.iff_triangles'' {s : Finset Point} {S : List Point}
 theorem ConvexIndep.iff_triangles' {s : Finset Point} (gp : Point.SetInGenPos s) :
     ConvexIndep s ↔ ∀ (t : Finset Point), t.card = 3 → t ⊆ s → EmptyShapeIn t s := by
   have : s = s.toList.toFinset := s.toList_toFinset.symm
-  rw [← ConvexEmptyIn.refl_iff, this, ← ConvexEmptyIn.iff_triangles' subset_rfl]
-  apply Point.SetInGenPos.of_nodup
-  simp [gp]
-  exact Finset.nodup_toList s
+  rw [← ConvexEmptyIn.refl_iff, ← ConvexEmptyIn.iff_triangles' subset_rfl]
+  exact gp
 
 theorem ConvexIndep.iff_triangles'' {s : Finset Point} (gp : Point.SetInGenPos s) :
     ConvexIndep s ↔
     ∀ᵉ (a ∈ s) (b ∈ s) (c ∈ s), a ≠ b → a ≠ c → b ≠ c →
       ∀ p ∈ s \ {a,b,c}, ¬PtInTriangle p a b c := by
-  have : s = s.toList.toFinset := s.toList_toFinset.symm
-  rw [← ConvexEmptyIn.refl_iff, this, ← ConvexEmptyIn.iff_triangles'' subset_rfl]
-  apply Point.SetInGenPos.of_nodup
-  simp [gp]
-  exact Finset.nodup_toList s
+  rw [← ConvexEmptyIn.refl_iff, ← ConvexEmptyIn.iff_triangles'' subset_rfl]
+  exact gp
 
 open Point in
 theorem split_convexHull (cvx : ConvexIndep S) :

--- a/Lean/Geo/Definitions/Structures.lean
+++ b/Lean/Geo/Definitions/Structures.lean
@@ -257,10 +257,10 @@ theorem EmptyShapeIn.split (cvx : ConvexIndep S) (ha : a ∈ S) (hb : b ∈ S)
     (H2 : EmptyShapeIn {x ∈ S | σ a b x ≠ .cw} P) : EmptyShapeIn S P := fun _ ⟨pP, pS⟩ hn =>
   (split_convexHull cvx ha hb hn).elim (H1 _ ⟨pP, mt And.left pS⟩) (H2 _ ⟨pP, mt And.left pS⟩)
 
-def HasEmptyKGon (n : Nat) (S : Set Point) : Prop :=
-  ∃ s : Finset Point, s.card = n ∧ ↑s ⊆ S ∧ ConvexEmptyIn s S
+def HasEmptyKGon (n : Nat) (P : Set Point) : Prop :=
+  ∃ S : Finset Point, S.card = n ∧ ↑S ⊆ P ∧ ConvexEmptyIn S P
 
-def HasConvexKGon (n : Nat) (S : Set Point) : Prop :=
-  ∃ s : Finset Point, s.card = n ∧ ↑s ⊆ S ∧ ConvexIndep s
+def HasConvexKGon (n : Nat) (P : Set Point) : Prop :=
+  ∃ S : Finset Point, S.card = n ∧ ↑S ⊆ P ∧ ConvexIndep S
 
 end Geo

--- a/Lean/Geo/Hexagon/TheMainTheorem.lean
+++ b/Lean/Geo/Hexagon/TheMainTheorem.lean
@@ -6,34 +6,27 @@ import Geo.Hexagon.Encoding
 namespace Geo
 open Classical LeanSAT Model
 
--- /-- This asserts that the CNF produced by `lake exe encode gon 6 17` is UNSAT -/
--- axiom unsat_6gon_cnf : (Geo.hexagonCNF (rlen := 17-1) (holes := false)).isUnsat
+variable (unsat_6hole_cnf : (Geo.hexagonCNF (rlen := 30-1) (holes := true)).isUnsat)
 
--- theorem gon_6_theorem (pts : List Point) (gp : Point.ListInGenPos pts)
---     (h : pts.length ≥ 17) : HasConvexKGon 6 pts.toFinset := by
---   refine HasConvexKGon_extension gp (fun pts gp h => ?_) h
---   by_contra h'
---   have noσgon : ¬σHasConvexKGon 6 pts.toFinset := mt (σHasConvexKGon_iff_HasConvexKGon gp).1 h'
---   have ⟨w, ⟨hw⟩⟩ := @symmetry_breaking pts (h ▸ by decide) gp
---   have noσgon' : ¬σHasEmptyKGonIf 6 (holes := false) w.toFinset :=
---     OrientationProperty_σHasConvexKGon.not (hw.toEquiv w.nodup) noσgon
---   have rlen_eq : w.rlen = 16 := Nat.succ_inj.1 <| hw.length_eq.symm.trans h
---   apply unsat_6gon_cnf
---   with_reducible
---     have := (PropForm.toICnf_sat _).2 ⟨w.toPropAssn false, w.satisfies_hexagonEncoding noσgon'⟩
---     rw [rlen_eq] at this
---     rwa [hexagonCNF]
-
-variable (unsat_6hole_cnf : (Geo.hexagonCNF (rlen := 30-1) (holes := true)).isUnsat) in
-theorem hole_6_theorem : holeNumber 6 ≤ 30 := by
-  refine holeNumber_le.2 fun pts h _ gp => by_contra fun h' => ?_
-  have noσtri : ¬σHasEmptyKGon 6 pts.toFinset := mt (σHasEmptyKGon_iff_HasEmptyKGon gp).1 h'
-  have ⟨w, ⟨hw⟩⟩ := @symmetry_breaking pts (h ▸ by decide) gp
+theorem hole_6_theorem : ∀ (pts : Finset Point),
+    Point.SetInGenPos pts → pts.card = 30 → HasEmptyKGon 6 pts := by
+  intro pts gp h
+  by_contra h'
+  have noσtri : ¬σHasEmptyKGon 6 pts := mt (σHasEmptyKGon_iff_HasEmptyKGon gp).1 h'
+  have ⟨w, ⟨hw⟩⟩ := @symmetry_breaking pts.toList (by simp [h]) gp.toList
   have noσtri' : ¬σHasEmptyKGonIf 6 (holes := true) w.toFinset :=
-    OrientationProperty_σHasEmptyKGon.not (hw.toEquiv w.nodup) noσtri
-  have rlen29 : w.rlen = 29 := Nat.succ_inj.1 <| hw.length_eq.symm.trans h
+    OrientationProperty_σHasEmptyKGon.not (hw.toEquiv w.nodup) (by simpa using noσtri)
+  have rlen29 : w.rlen = 29 := Nat.succ_inj.1 <| hw.length_eq.symm.trans (by simp; simpa using h)
   apply unsat_6hole_cnf
   with_reducible
     have := (PropForm.toICnf_sat _).2 ⟨w.toPropAssn, w.satisfies_hexagonEncoding noσtri'⟩
     rw [rlen29] at this
     rwa [hexagonCNF]
+
+theorem hole_6_theorem' : holeNumber 6 ≤ ↑(30 : Nat) := by
+  rw [holeNumber_le]
+  intro pts h nodup genpos
+  apply hole_6_theorem
+  · exact unsat_6hole_cnf
+  · apply genpos.toFinset
+  · rw [List.toFinset_card_of_nodup nodup]; exact h

--- a/Lean/Geo/LowerBound/HoleCheckerProof.lean
+++ b/Lean/Geo/LowerBound/HoleCheckerProof.lean
@@ -795,4 +795,4 @@ theorem hole_lower_bound {r : Nat} (points : List NPoint)
     points.length + 1 ≤ holeNumber (r+3) := by
   let ⟨(), eq⟩ := Option.isSome_iff_exists.1 checkIt
   let ⟨H1, H2, H3⟩ := of_holeCheck' MaybeHoles.yes_wf eq
-  simpa using holeNumber_lower_bound (↑'points) H1 H2 (mt (σHasEmptyKGon_iff_HasEmptyKGon H2).2 H3)
+  simpa using holeNumber_lower_bound (↑'points) H1 H2 (mt (σHasEmptyKGon_iff_HasEmptyKGon H2.toFinset).2 H3)

--- a/Lean/Geo/Naive/TheMainTheorem.lean
+++ b/Lean/Geo/Naive/TheMainTheorem.lean
@@ -8,7 +8,7 @@ open Classical LeanSAT Model
 
 theorem empty_kgon_naive (unsat : (Geo.naiveCNF k (r+2)).isUnsat) : holeNumber k ≤ r + 3 := by
   refine holeNumber_le.2 fun pts h _ gp => by_contra fun h' => ?_
-  have noσtri : ¬σHasEmptyKGon k pts.toFinset := mt (σHasEmptyKGon_iff_HasEmptyKGon gp).1 h'
+  have noσtri : ¬σHasEmptyKGon k pts.toFinset := mt (σHasEmptyKGon_iff_HasEmptyKGon gp.toFinset).1 h'
   have ⟨w, ⟨hw⟩⟩ := @symmetry_breaking pts (h ▸ Nat.le_add_left ..) gp
   have noσtri' : ¬σHasEmptyKGon k w.toFinset :=
     OrientationProperty_σHasEmptyKGon.not (hw.toEquiv w.nodup) noσtri


### PR DESCRIPTION
Modifies `hole_6_theorem` to be about sets rather than lists (as requested by reviewer 1). Also modifies the code base so that `hole_6_theorem` appears exactly as in the paper.